### PR TITLE
add missing `context`

### DIFF
--- a/pset.typ
+++ b/pset.typ
@@ -51,7 +51,7 @@
       inset: 1em,
       fill: luma(98%)
     )[
-      #show raw.line: l => {
+      #show raw.line: l => context {
         box(width:measure([#it.lines.last().count]).width, align(right, text(fill: luma(50%))[#l.number]))
         h(0.5em)
         l.body


### PR DESCRIPTION
`measure` function can only be used under a `context`. See [test-pset project](https://typst.app/project/wtBcKumJR1RMgwhCnql1Wh) and comment out line 54/55 to see the difference.