### PR TITLE
replace box with block for code blocks

### DIFF
--- a/pset.typ
+++ b/pset.typ
@@ -1,78 +1,71 @@
-#let pset(class: "6.100",
+#let pset(
+  class: "6.100",
   title: "PSET 0",
   student: "Alyssa P. Hacker",
   date: datetime.today(),
   subproblems: "1.1.a.i",
   collaborators: (),
-  doc
-) = {[
-/* Convert collaborators to a string if necessary */
-#let collaborators=if type(collaborators) == array {collaborators.join(", ")} else {collaborators}
+  doc,
+) = {
+  [
+    /* Convert collaborators to a string if necessary */
+    #let collaborators = if type(collaborators) == array { collaborators.join(", ") } else { collaborators }
 
-/* Problem + subproblem headings */
-#set heading(numbering: (..nums) => {
-    nums = nums.pos()
-    if nums.len() == 1 {
-      [Problem #nums.at(0):]
-    } else {
-      numbering(subproblems, ..nums)
-    }
-})
-
-/* Set metadata */
-#set document(
-  title: [#class - #title],
-  author: student,
-  date: date,
-)
-
-/* Set up page numbering and continued page headers */
-#set page(
-  numbering: "1",
-  header: context {
-  if counter(page).get().first() > 1 [
-    #set text(style: "italic")
-    #class -- #title
-    #h(1fr)
-    #student
-    #if collaborators != none {[w/ #collaborators]}
-    #block(line(length: 100%, stroke: 0.5pt), above: 0.6em)
-  ]
-})
-
-/* Add numbering and some color to code blocks */
-#show raw.where(block: true): it => {
-  block[
-    #h(1fr)
-    #box(
-      width: 100%-0.5em,
-      radius: 0.3em,
-      stroke: luma(50%),
-      inset: 1em,
-      fill: luma(98%)
-    )[
-      #show raw.line: l => context {
-        box(width:measure([#it.lines.last().count]).width, align(right, text(fill: luma(50%))[#l.number]))
-        h(0.5em)
-        l.body
+    /* Problem + subproblem headings */
+    #set heading(numbering: (..nums) => {
+      nums = nums.pos()
+      if nums.len() == 1 {
+        [Problem #nums.at(0):]
+      } else {
+        numbering(subproblems, ..nums)
       }
-      #it
-    ]
+    })
+
+    /* Set metadata */
+    #set document(title: [#class - #title], author: student, date: date)
+
+    /* Set up page numbering and continued page headers */
+    #set page(numbering: "1", header: context {
+      if counter(page).get().first() > 1 [
+        #set text(style: "italic")
+        #class -- #title
+        #h(1fr)
+        #student
+        #if collaborators != none { [w/ #collaborators] }
+        #block(line(length: 100%, stroke: 0.5pt), above: 0.6em)
+      ]
+    })
+
+    /* Add numbering and some color to code blocks */
+    #show raw.where(block: true): it => {
+      block[
+        #h(1fr)
+        #box(width: 100% - 0.5em, radius: 0.3em, stroke: luma(50%), inset: 1em, fill: luma(98%))[
+          #show raw.line: l => context {
+            box(width: measure([#it.lines.last().count]).width, align(right, text(fill: luma(50%))[#l.number]))
+            h(0.5em)
+            l.body
+          }
+          #it
+        ]
+      ]
+    }
+
+    /* Make the title */
+    #align(center, {
+      text(size: 1.6em, weight: "bold")[#class -- #title \ ]
+      text(size: 1.2em, weight: "semibold")[#student \ ]
+      emph[
+        #date.display("[year]-[month]-[day]")
+        #if collaborators != none {
+          [
+            \ Collaborators: #collaborators
+          ]
+        }
+      ]
+      box(line(length: 100%, stroke: 1pt))
+    })
+
+    #doc
   ]
 }
-
-/* Make the title */
-#align(center, {
-  text(size: 1.6em, weight: "bold")[#class -- #title \ ]
-  text(size: 1.2em, weight: "semibold")[#student \ ]
-  emph[
-    #date.display("[year]-[month]-[day]") 
-    #if collaborators != none {[
-      \ Collaborators: #collaborators
-    ]}
-  ]
-  box(line(length: 100%, stroke: 1pt))
-})
-
-#doc
-]}

--- a/pset.typ
+++ b/pset.typ
@@ -38,16 +38,13 @@
 
     /* Add numbering and some color to code blocks */
     #show raw.where(block: true): it => {
-      block[
-        #h(1fr)
-        #box(width: 100% - 0.5em, radius: 0.3em, stroke: luma(50%), inset: 1em, fill: luma(98%))[
-          #show raw.line: l => context {
-            box(width: measure([#it.lines.last().count]).width, align(right, text(fill: luma(50%))[#l.number]))
-            h(0.5em)
-            l.body
-          }
-          #it
-        ]
+      block(width: 100% - 0.5em, radius: 0.3em, stroke: luma(50%), inset: 1em, fill: luma(98%))[
+        #show raw.line: l => context {
+          box(width: measure([#it.lines.last().count]).width, align(right, text(fill: luma(50%))[#l.number]))
+          h(0.5em)
+          l.body
+        }
+        #it
       ]
     }
 

--- a/pset.typ
+++ b/pset.typ
@@ -12,29 +12,34 @@
     #let collaborators = if type(collaborators) == array { collaborators.join(", ") } else { collaborators }
 
     /* Problem + subproblem headings */
-    #set heading(numbering: (..nums) => {
-      nums = nums.pos()
-      if nums.len() == 1 {
-        [Problem #nums.at(0):]
-      } else {
-        numbering(subproblems, ..nums)
-      }
-    })
+    #set heading(
+      numbering: (..nums) => {
+        nums = nums.pos()
+        if nums.len() == 1 {
+          [Problem #nums.at(0):]
+        } else {
+          numbering(subproblems, ..nums)
+        }
+      },
+    )
 
     /* Set metadata */
     #set document(title: [#class - #title], author: student, date: date)
 
     /* Set up page numbering and continued page headers */
-    #set page(numbering: "1", header: context {
-      if counter(page).get().first() > 1 [
-        #set text(style: "italic")
-        #class -- #title
-        #h(1fr)
-        #student
-        #if collaborators != none { [w/ #collaborators] }
-        #block(line(length: 100%, stroke: 0.5pt), above: 0.6em)
-      ]
-    })
+    #set page(
+      numbering: "1",
+      header: context {
+        if counter(page).get().first() > 1 [
+          #set text(style: "italic")
+          #class -- #title
+          #h(1fr)
+          #student
+          #if collaborators != none { [w/ #collaborators] }
+          #block(line(length: 100%, stroke: 0.5pt), above: 0.6em)
+        ]
+      },
+    )
 
     /* Add numbering and some color to code blocks */
     #show raw.where(block: true): it => {
@@ -49,19 +54,22 @@
     }
 
     /* Make the title */
-    #align(center, {
-      text(size: 1.6em, weight: "bold")[#class -- #title \ ]
-      text(size: 1.2em, weight: "semibold")[#student \ ]
-      emph[
-        #date.display("[year]-[month]-[day]")
-        #if collaborators != none {
-          [
-            \ Collaborators: #collaborators
-          ]
-        }
-      ]
-      box(line(length: 100%, stroke: 1pt))
-    })
+    #align(
+      center,
+      {
+        text(size: 1.6em, weight: "bold")[#class -- #title \ ]
+        text(size: 1.2em, weight: "semibold")[#student \ ]
+        emph[
+          #date.display("[year]-[month]-[day]")
+          #if collaborators != none {
+            [
+              \ Collaborators: #collaborators
+            ]
+          }
+        ]
+        box(line(length: 100%, stroke: 1pt))
+      },
+    )
 
     #doc
   ]


### PR DESCRIPTION
Solves issue #4.

Here is the current approach:
```typ
#show raw.where(block: true): it => {
  block[
    #h(1fr)
    #box(width: 100% - 0.5em, radius: 0.3em, stroke: luma(50%), inset: 1em, fill: luma(98%))[
      #show raw.line: l => context {
        box(width: measure([#it.lines.last().count]).width, align(right, text(fill: luma(50%))[#l.number]))
        h(0.5em)
        l.body
      }
      #it
    ]
  ]
}

#raw(lorem(1000), block: true)
```
<img width="474" alt="Screenshot 2025-03-03 at 5 56 28 PM" src="https://github.com/user-attachments/assets/7f7465c7-464f-47a8-8fff-c6f1eab51211" />

Replacing with block:
```typ
#show raw.where(block: true): it => {
  block(width: 100% - 0.5em, radius: 0.3em, stroke: luma(50%), inset: 1em, fill: luma(98%))[
    #show raw.line: l => context {
      box(width: measure([#it.lines.last().count]).width, align(right, text(fill: luma(50%))[#l.number]))
      h(0.5em)
      l.body
    }
    #it
  ]
}

#raw(lorem(1000), block: true)
```
We get the following:

<img width="334" alt="Screenshot 2025-03-03 at 5 57 17 PM" src="https://github.com/user-attachments/assets/9de76918-f317-43d6-86e1-519374bbed48" />

This seems more desirable.