### PR TITLE
feat: allow specifying date format

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,5 +19,6 @@ The `pset` function takes the following named arguments:
 - `student` (string): Student completing the assignment.
 - `title` (string): Title of the assignment.
 - `date` (datetime): Date to be displayed on the assignment.
+- `date-format` (string): Date format string to use for displaying `date` (see [Typst docs](https://typst.app/docs/reference/foundations/datetime/) for formatting instructions)
 - `collaborators` (array of strings): Collaborators that worked on the assignment with the student. Can be `()`.
 - `subproblems` (string): Numbering scheme for the subproblems.

--- a/pset.typ
+++ b/pset.typ
@@ -3,6 +3,7 @@
   title: "PSET 0",
   student: "Alyssa P. Hacker",
   date: datetime.today(),
+  date-format: "[month repr:long] [day padding:none], [year]",
   subproblems: "1.1.a.i",
   collaborators: (),
   doc,
@@ -60,7 +61,7 @@
         text(size: 1.6em, weight: "bold")[#class -- #title \ ]
         text(size: 1.2em, weight: "semibold")[#student \ ]
         emph[
-          #date.display("[year]-[month]-[day]")
+          #date.display(date-format)
           #if collaborators != none {
             [
               \ Collaborators: #collaborators


### PR DESCRIPTION
most templates allow this; this sets a default date format that looks like "January 1, 2026"

the default format can be changed with the `date-format` argument